### PR TITLE
レプリケーション処理の修正

### DIFF
--- a/lib/ruboty/moneta/brains/moneta.rb
+++ b/lib/ruboty/moneta/brains/moneta.rb
@@ -30,11 +30,11 @@ module Ruboty
       private
 
       def push
-        master[KEY] = data
+        master[key] = data
       end
 
       def pull
-        if str = master[KEY]
+        if str = master[key]
           str
         end
       rescue TypeError
@@ -42,7 +42,7 @@ module Ruboty
 
       def replicate
         slaves.each do |slave|
-          slave[KEY] = data
+          slave[key] = data
         end
       end
 
@@ -72,6 +72,10 @@ module Ruboty
         ENV["MONETA_BACKEND_SLAVE"]
       end
 
+      def namespace
+        ENV["MONETA_NAMESPACE"] || "ruboty"
+      end
+
       def fetch_option(backend)
         prefix = backend.to_s.underscore.upcase
         ENV.reduce({}) do |option, env|
@@ -97,6 +101,10 @@ module Ruboty
         else
           []
         end
+      end
+
+      def key
+        @key ||= "#{namespace}:#{KEY}"
       end
     end
   end

--- a/lib/ruboty/moneta/brains/moneta.rb
+++ b/lib/ruboty/moneta/brains/moneta.rb
@@ -30,19 +30,19 @@ module Ruboty
       private
 
       def push
-        master[KEY] = Marshal.dump(data)
+        master[KEY] = data
       end
 
       def pull
         if str = master[KEY]
-          Marshal.load(str)
+          str
         end
       rescue TypeError
       end
 
       def replicate
         slaves.each do |slave|
-          slave[KEY] = Marshal.dump(data)
+          slave[KEY] = data
         end
       end
 
@@ -67,7 +67,7 @@ module Ruboty
       end
 
       def slave_backend
-        eval(ENV["MONETA_BACKEND_SLAVE"])
+        eval(ENV["MONETA_BACKEND_SLAVE"] || "")
       rescue NameError
         ENV["MONETA_BACKEND_SLAVE"]
       end


### PR DESCRIPTION
2重のmarshal.dumpをしないように修正

MONETA_BACKEND_SLAVEのevalが定義なしを考慮してなかったので修正
redisからのreplicationにnamespaceが必要っぽいので修正
